### PR TITLE
Fix Installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Django.
 
 In order to get started, you need to install the project:
 
-    $ pip install -e https://github.com/linovia/django-agile-boards.git
+    $ pip install git+https://github.com/linovia/django-agile-boards.git
 
 You can then bootstrap the installation process by generating a sample
 configuration file:


### PR DESCRIPTION
The `pip install` command fails:

```
pip install -e https://github.com/linovia/django-agile-boards.git    
https://github.com/linovia/django-agile-boards.git should either be a path to a local project or a VCS url beginning with svn+, git+, hg+, or bzr+
```

This PR fixes it. @xordoquy ?
